### PR TITLE
Bump release .NET 5 to .NET 6 csproj

### DIFF
--- a/Tailspin.SpaceGame.Web/Tailspin.SpaceGame.Web.csproj
+++ b/Tailspin.SpaceGame.Web/Tailspin.SpaceGame.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ProjectGuid>{A0C4E31E-AC75-4F39-9F59-0AA19D9B8F46}</ProjectGuid>
   </PropertyGroup>
 


### PR DESCRIPTION
The Azure App Service runtime is on .NET 6 (LTS)