### PR TITLE
Moving UI test project to .NET 6

### DIFF
--- a/Tailspin.SpaceGame.Web.UITests/Tailspin.SpaceGame.Web.UITests.csproj
+++ b/Tailspin.SpaceGame.Web.UITests/Tailspin.SpaceGame.Web.UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PublishChromeDriver>True</PublishChromeDriver>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
In the exercise "Run the UI tests locally and in the pipeline" https://docs.microsoft.com/en-us/learn/modules/run-functional-tests-azure-pipelines/6-run-ui-tests?tabs=export-macos , we check out the selenium branch and run the projects locally, but before the project was still targeting .NET 5, this pull request fixes it.